### PR TITLE
Correct import ID for aws_default_route_table

### DIFF
--- a/src/tfblocks/aws_resources.py
+++ b/src/tfblocks/aws_resources.py
@@ -2296,9 +2296,9 @@ class AwsDefaultNetworkAcl(BaseResource):
 
 class AwsDefaultRouteTable(BaseResource):
     def _get_import_id(self) -> str | None:
-        if not self.has_attributes(["default_route_table_id"]):
+        if not self.has_attributes(["vpc_id"]):
             return None
-        return self.attributes["default_route_table_id"]
+        return self.attributes["vpc_id"]
 
 
 class AwsDefaultSecurityGroup(BaseResource):


### PR DESCRIPTION
aws_default_route_table expects vpc_id in id field when importing: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_route_table#import